### PR TITLE
feat: Add image.

### DIFF
--- a/.github/workflows/build-flow.yml
+++ b/.github/workflows/build-flow.yml
@@ -1,0 +1,72 @@
+name: ci
+
+on:
+  schedule:
+    - cron: '0 10 * * *' # every day at 10am
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    strategy:
+      matrix:
+        php: [ "7.2", "7.3", "7.4", "8.0", "8.1", "8.2" ]
+        node: [ "12", "14", "16", "18" ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker Image Update Checker
+        id: baseupdatecheck
+        uses: lucacome/docker-image-update-checker@v1.1.0
+        with:
+          base-image: "thecodingmachine/php:${{ matrix.php }}-v4-slim-cli"
+          image: "kellerkinder/pipeline-image:PHP_${{ matrix.php }}-NODE_${{ matrix.node }}"
+        continue-on-error: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Build
+        id: docker_build
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: .
+          push: true
+          tags: "localhost:5000/kellerkinder/pipeline-image:PHP_${{ matrix.php }}-NODE_${{ matrix.node }}"
+          build-args: |
+            PHP_VERSION=${{ matrix.php }}
+            NODE_VERSION=${{ matrix.node }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Test
+        run: |
+          docker buildx imagetools inspect localhost:5000/kellerkinder/pipeline-image:PHP_${{ matrix.php }}-NODE_${{ matrix.node }}
+          docker run --rm localhost:5000/kellerkinder/pipeline-image:PHP_${{ matrix.php }}-NODE_${{ matrix.node }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Push
+        id: docker_build_push
+        uses: docker/build-push-action@v3.2.0
+        with:
+          push: true
+          tags: "kellerkinder/pipeline-image:PHP_${{ matrix.php }}-NODE_${{ matrix.node }}"
+          build-args: |
+            PHP_VERSION=${{ matrix.php }}
+            NODE_VERSION=${{ matrix.node }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}

--- a/.github/workflows/legacy-build-flow.yml
+++ b/.github/workflows/legacy-build-flow.yml
@@ -1,0 +1,69 @@
+name: legacy ci
+
+on:
+  schedule:
+    - cron: '0 10 * * *' # every day at 10am
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    strategy:
+      matrix:
+        php: [ "7.2", "7.3", "7.4", "8.0", "8.1", "8.2" ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker Image Update Checker
+        id: baseupdatecheck
+        uses: lucacome/docker-image-update-checker@v1.1.0
+        with:
+          base-image: "thecodingmachine/php:${{ matrix.php }}-v4-slim-cli"
+          image: "kellerkinder/pipeline-image:${{ matrix.php }}"
+        continue-on-error: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Build
+        id: docker_build
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: .
+          push: true
+          tags: "localhost:5000/kellerkinder/pipeline-image:${{ matrix.php }}"
+          build-args: |
+            PHP_VERSION=${{ matrix.php }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Test
+        run: |
+          docker buildx imagetools inspect localhost:5000/kellerkinder/pipeline-image:${{ matrix.php }}
+          docker run --rm localhost:5000/kellerkinder/pipeline-image:${{ matrix.php }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Push
+        id: docker_build_push
+        uses: docker/build-push-action@v3.2.0
+        with:
+          push: true
+          tags: "kellerkinder/pipeline-image:${{ matrix.php }}"
+          build-args: |
+            PHP_VERSION=${{ matrix.php }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}

--- a/.github/workflows/legacy-test-build-flow.yml
+++ b/.github/workflows/legacy-test-build-flow.yml
@@ -1,0 +1,58 @@
+name: legacy test build
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    strategy:
+      matrix:
+        php: [ "7.2", "7.3", "7.4", "8.0", "8.1", "8.2" ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker Image Update Checker
+        id: baseupdatecheck
+        uses: lucacome/docker-image-update-checker@v1.1.0
+        with:
+          base-image: "thecodingmachine/php:${{ matrix.php }}-v4-slim-cli"
+          image: "kellerkinder/pipeline-image:${{ matrix.php }}"
+        continue-on-error: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Build
+        id: docker_build
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: .
+          push: true
+          tags: "localhost:5000/kellerkinder/pipeline-image:${{ matrix.php }}"
+          build-args: |
+            PHP_VERSION=${{ matrix.php }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Test
+        run: |
+          docker buildx imagetools inspect localhost:5000/kellerkinder/pipeline-image:${{ matrix.php }}
+          docker run --rm localhost:5000/kellerkinder/pipeline-image:${{ matrix.php }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}

--- a/.github/workflows/test-build-flow.yml
+++ b/.github/workflows/test-build-flow.yml
@@ -1,0 +1,60 @@
+name: test build
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    strategy:
+      matrix:
+        php: [ "7.2", "7.3", "7.4", "8.0", "8.1", "8.2" ]
+        node: [ "12", "14", "16", "18" ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker Image Update Checker
+        id: baseupdatecheck
+        uses: lucacome/docker-image-update-checker@v1.1.0
+        with:
+          base-image: "thecodingmachine/php:${{ matrix.php }}-v4-slim-cli"
+          image: "kellerkinder/pipeline-image:PHP_${{ matrix.php }}-NODE_${{ matrix.node }}"
+        continue-on-error: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Build
+        id: docker_build
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: .
+          push: true
+          tags: "localhost:5000/kellerkinder/pipeline-image:PHP_${{ matrix.php }}-NODE_${{ matrix.node }}"
+          build-args: |
+            PHP_VERSION=${{ matrix.php }}
+            NODE_VERSION=${{ matrix.node }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}
+      - name: Test
+        run: |
+          docker buildx imagetools inspect localhost:5000/kellerkinder/pipeline-image:PHP_${{ matrix.php }}-NODE_${{ matrix.node }}
+          docker run --rm localhost:5000/kellerkinder/pipeline-image:PHP_${{ matrix.php }}-NODE_${{ matrix.node }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || steps.baseupdatecheck.outputs.needs-updating == 'true' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+ARG PHP_VERSION=7.2
+ARG NODE_VERSION=14
+ARG PHP_EXTENSIONS="intl"
+
+FROM thecodingmachine/php:$PHP_VERSION-v4-slim-cli
+
+ADD https://getcomposer.org/download/latest-1.x/composer.phar /usr/local/bin/composer1
+ADD https://getcomposer.org/download/latest-2.x/composer.phar /usr/local/bin/composer2
+
+USER root
+
+RUN apt-get update -q \
+    && apt-get upgrade -y -q \
+    && apt-get install -y patch rsync make jq \
+    && rm -f /usr/local/bin/composer \
+    && rm -rf ~/.composer \
+    && cd /usr/local/bin/ \
+    && chmod 755 composer1 composer2 \
+    && ln -s composer2 composer \
+    && apt-get autoremove -yq --purge \
+    && apt-get autoclean -yq \
+    && apt-get clean \
+    && rm -rf /var/cache/apt/ /var/lib/apt/lists/* /var/log/* /tmp/* /var/tmp/* /usr/share/doc /usr/share/doc-base /usr/share/groff/* /usr/share/info/* /usr/share/linda/* /usr/share/lintian/overrides/* /usr/share/locale/* /usr/share/man/* /usr/share/locale/* /usr/share/gnome/help/*/* /usr/share/doc/kde/HTML/*/* /usr/share/omf/*/*-*.emf
+
+USER docker

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # shopware-deploy-image
+
+> Expanded tooling for PHP pipelines
+
+---
+
+Builds from: [thecodingmachine/php](https://github.com/thecodingmachine/docker-images-php) with tag `$PHP_VER-v4-slim-cli`
+
+## Features
+### Currently we're building the following PHP versions:
+* PHP 8.1
+* PHP 8.0
+* PHP 7.4
+* PHP 7.3
+* PHP 7.2
+
+#### With these extensions:
+* intl
+
+### Composer
+  * composer v1 (`/usr/local/bin/composer1`)
+  * composer v2 (`/usr/local/bin/composer2`)
+    * `/usr/local/bin/composer` is a symbolic link to v2
+
+### Additional packages:
+  * [patch](https://wiki.ubuntuusers.de/patch/)
+  * [rsync](https://wiki.ubuntuusers.de/rsync/)
+  * [make](https://wiki.ubuntuusers.de/Makefile/)
+  * [jq](https://wiki.ubuntuusers.de/jq/)
+
+### Node
+We create and tag different images with nodes `12`, `14` and `16`.
+
+As a default for the legacy images (without explicit node tag), node in version `14` is used.
+
+## License
+MIT, see [`LICENSE`](./LICENSE)


### PR DESCRIPTION
Changing of the target image name and pushing to GitHub's registry remains to do.

The scheduled GitHub Actions workflows require a manual trigger once a month to keep the schedule intact without any code changes.